### PR TITLE
MDL-73396 auth_oauth2: link non-suspended account on oauth login

### DIFF
--- a/public/auth/oauth2/classes/auth.php
+++ b/public/auth/oauth2/classes/auth.php
@@ -465,18 +465,31 @@ class auth extends \auth_plugin_base {
             $mappeduser = get_complete_user_data('id', $linkedlogin->get('userid'));
 
             if ($mappeduser && $mappeduser->suspended) {
-                $failurereason = AUTH_LOGIN_SUSPENDED;
-                $event = \core\event\user_login_failed::create([
-                    'userid' => $mappeduser->id,
-                    'other' => [
-                        'username' => $userinfo['username'],
-                        'reason' => $failurereason
-                    ]
-                ]);
-                $event->trigger();
-                $SESSION->loginerrormsg = get_string('invalidlogin');
-                $client->log_out();
-                redirect(new moodle_url('/login/index.php'));
+                // Check if there's another user with the same email that is not suspended.
+                $moodleuser = \core_user::get_user_by_email($userinfo['email']);
+                if ($moodleuser->id == $mappeduser->id) {
+                    $failurereason = AUTH_LOGIN_SUSPENDED;
+                    $event = \core\event\user_login_failed::create([
+                        'userid' => $mappeduser->id,
+                        'other' => [
+                            'username' => $userinfo['username'],
+                            'reason' => $failurereason,
+                        ],
+                    ]);
+                    $event->trigger();
+                    $SESSION->loginerrormsg = get_string('invalidlogin');
+                    $client->log_out();
+                    redirect(new moodle_url('/login/index.php'));
+                } else if ($moodleuser && !$moodleuser->suspended) {
+                    // Update the OAuth2 linked login to point to the active user account.
+                    $linkedlogin->set('userid', $moodleuser->id);
+                    $linkedlogin->set('timemodified', time());
+                    $linkedlogin->update();
+
+                    // Update user fields and continue with login
+                    $userinfo = $this->update_user($userinfo, $moodleuser);
+                    $userwasmapped = true;
+                }
             } else if ($mappeduser && ($mappeduser->confirmed || !$issuer->get('requireconfirmation'))) {
                 // Update user fields.
                 $userinfo = $this->update_user($userinfo, $mappeduser);


### PR DESCRIPTION
Hi Guillermo, 

This PR is just for your review -> please do not merge I will add the commit manually. 

Explanation of the changes:

### Reason for previous failure:
- Our previous change was only working in cases where there were two users (one suspended) and neither account was linked with OAuth2 in the site. The SQL we added would pick the proper account to login with (the non-suspended account).
- The case where a user logs in using OAuth2, and their account is linked -> then that user is suspended and another account with the same email exists, the next time you try to log in with OAuth2 (with the email associated with both accounts) the login fails
- The current logic in `oauth2/classes/auth.php` checks if we have a linked account, if the account is suspended, then throw an error and return the user to the login screen with the message "Invalid login, please try again"

### Changes
- I added a check in `oauth2/classes/auth.php` to first check if we have another user account that is active with the same email. I used the function we previously changed `\core_user::get_user_by_email($email)` to check if we another active account under the same email.
- `get_user_by_email` returns the most recently created user account under that email, and it will return the active accounts first if any exist. 
- We the return value of `get_user_by_email` to check if it matches the account that is currently linked with OAuth2.
- If the user returned is in fact a different account than the original acount that was linked with OAuth2, then we check if the user is active and update the linked login to be the active user.

### Testing
When logging in with OAuth2 (all accounts having the same email assocaited with them):
1. Having two accounts (unlinked with OAuth2) will choose the most recently created user account to log in with
2. Having two accounts (unlinked with OAuth2 and one suspended) -> The active account will be linked with OAuth2 upon login
3. Having two accounts (one is linked with OAuth2 and suspended) -> The active account will be linked with OAuth2 and the suspended account will be unlinked upon login
4. Having two accounts (both are linked with OAuth2 and one is suspended) -> The active account will be used for login and linked with OAuth2 
6. Having more than two accounts will follow the same logic -> accounts will be prioritized for login based on active status/how recently the accounts were created.